### PR TITLE
Use cachetool to selectively flush OPcache

### DIFF
--- a/src/Recipes/AppRecipe.php
+++ b/src/Recipes/AppRecipe.php
@@ -204,7 +204,7 @@ class AppRecipe
 
     public static function flushOpcache(): void
     {
-        if (!test("-x cachetool.phar")) {
+        if (!test("[ -x cachetool.phar ]")) {
             info("downloading cachetool");
 
             run("curl -sLO https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar");

--- a/src/Recipes/AppRecipe.php
+++ b/src/Recipes/AppRecipe.php
@@ -9,7 +9,7 @@ use Mittwald\ApiClient\Generated\V2\Clients\Project\ListProjects\ListProjectsReq
 use Mittwald\ApiClient\Generated\V2\Schemas\App\AppInstallation;
 use Mittwald\Deployer\Client\AppClient;
 use Mittwald\Deployer\Util\SanityCheck;
-use function Deployer\{after, commandExist, currentHost, get, info, parse, run, set, Support\starts_with, task, test};
+use function Deployer\{after, currentHost, get, info, parse, run, set, Support\starts_with, task, test};
 use function Mittwald\Deployer\get_array;
 use function Mittwald\Deployer\get_str;
 use function Mittwald\Deployer\get_str_nullable;

--- a/src/Recipes/AppRecipe.php
+++ b/src/Recipes/AppRecipe.php
@@ -9,7 +9,7 @@ use Mittwald\ApiClient\Generated\V2\Clients\Project\ListProjects\ListProjectsReq
 use Mittwald\ApiClient\Generated\V2\Schemas\App\AppInstallation;
 use Mittwald\Deployer\Client\AppClient;
 use Mittwald\Deployer\Util\SanityCheck;
-use function Deployer\{after, currentHost, get, info, parse, run, set, Support\starts_with, task};
+use function Deployer\{after, commandExist, currentHost, get, info, parse, run, set, Support\starts_with, task, test};
 use function Mittwald\Deployer\get_array;
 use function Mittwald\Deployer\get_str;
 use function Mittwald\Deployer\get_str_nullable;
@@ -204,7 +204,12 @@ class AppRecipe
 
     public static function flushOpcache(): void
     {
-        run('touch /etc/php/php.ini');
+        if (!test("-x cachetool.phar")) {
+            run("curl -sLO https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar");
+            run("chmod +x cachetool.phar");
+        }
+
+        run('./cachetool.phar opcache:invalidate:scripts --fcgi=127.0.0.1:9000 {{ deploy_path }}');
     }
 
 }

--- a/src/Recipes/AppRecipe.php
+++ b/src/Recipes/AppRecipe.php
@@ -99,6 +99,8 @@ class AppRecipe
             'php' => '{{php_version}}',
         ]);
 
+        set('mittwald_local_bin', '{{ deploy_path }}/bin');
+
         task('mittwald:discover', function (): void {
             static::discover();
         })
@@ -204,14 +206,15 @@ class AppRecipe
 
     public static function flushOpcache(): void
     {
-        if (!test("[ -x cachetool.phar ]")) {
+        if (!test("[ -x {{ mittwald_local_bin }}/cachetool.phar ]")) {
             info("downloading cachetool");
 
-            run("curl -sLO https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar");
-            run("chmod +x cachetool.phar");
+            run("mkdir -p {{ mittwald_local_bin }}");
+            run("curl -sL https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar > {{ mittwald_local_bin }}/cachetool.phar");
+            run("chmod +x {{ mittwald_local_bin }}/cachetool.phar");
         }
 
-        run('./cachetool.phar opcache:invalidate:scripts --fcgi=127.0.0.1:9000 {{ deploy_path }}');
+        run('{{ mittwald_local_bin }}//cachetool.phar opcache:invalidate:scripts --fcgi=127.0.0.1:9000 {{ deploy_path }}');
         info("opcache flushed");
     }
 

--- a/src/Recipes/AppRecipe.php
+++ b/src/Recipes/AppRecipe.php
@@ -205,11 +205,14 @@ class AppRecipe
     public static function flushOpcache(): void
     {
         if (!test("-x cachetool.phar")) {
+            info("downloading cachetool");
+
             run("curl -sLO https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar");
             run("chmod +x cachetool.phar");
         }
 
         run('./cachetool.phar opcache:invalidate:scripts --fcgi=127.0.0.1:9000 {{ deploy_path }}');
+        info("opcache flushed");
     }
 
 }


### PR DESCRIPTION
This PR changes the `mittwald:opcache:flush` command to use [CacheTool](https://github.com/gordalina/cachetool) 
instead of using the `touch php.ini` hack; this is more reliable and allows flushing the OPCache selectively for 
the specific app.
