### PR TITLE
Wait until SSH user is avaible after creating

### DIFF
--- a/src/Recipes/SSHUserRecipe.php
+++ b/src/Recipes/SSHUserRecipe.php
@@ -73,12 +73,12 @@ class SSHUserRecipe
 
         currentHost()->set('remote_user', $remoteUser);
 
-        $backoff = 3;
+        $backoff = 5;
         for ($attempts = 10; $attempts > 0; $attempts--) {
             try {
                 run("true");
             } catch (\Exception $e) {
-                info("SSH user <fg=magenta;options=bold>{$remoteUser}</> not yet available, retrying in {$backoff} seconds...");
+                info("SSH user <fg=magenta;options=bold>{$remoteUser}</> not yet available, retrying in {$backoff} seconds... ({$e->getMessage()})");
                 sleep($backoff);
                 continue;
             }

--- a/src/Recipes/SSHUserRecipe.php
+++ b/src/Recipes/SSHUserRecipe.php
@@ -76,7 +76,7 @@ class SSHUserRecipe
         $backoff = 5;
         for ($attempts = 10; $attempts > 0; $attempts--) {
             try {
-                run("true");
+                run("/bin/true");
             } catch (\Exception $e) {
                 info("SSH user <fg=magenta;options=bold>{$remoteUser}</> not yet available, retrying in {$backoff} seconds... ({$e->getMessage()})");
                 sleep($backoff);


### PR DESCRIPTION
- Wait until created SSH user is actually available
- More verbosity
- Use full path to run "true"
- Run readiness check in its own task (after config is set up)
